### PR TITLE
59 bug cors error bij leerlingsites api in development

### DIFF
--- a/frontend/src/renderer/index.html
+++ b/frontend/src/renderer/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="nl" class="light">
 
 <head>
   <meta charset="UTF-8" />

--- a/frontend/src/renderer/index.html
+++ b/frontend/src/renderer/index.html
@@ -1,22 +1,19 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <title>Mijn Rooster</title>
-    <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
-    <link
-      href="https://fonts.googleapis.com/css2?family=Overpass:wght@400;600;700&display=swap"
-      rel="stylesheet"
-    />
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src *"
-    />
-    <script type="module" src="/src/easteregg.js"></script>
-  </head>
 
-  <body class="bg-white dark:bg-gray-800 select-none font-serif">
-    <div id="app" class="p-5 flex flex-col h-dvh"></div>
-    <script type="module" src="/src/main.js"></script>
-  </body>
+<head>
+  <meta charset="UTF-8" />
+  <title>Mijn Rooster</title>
+  <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
+  <link href="https://fonts.googleapis.com/css2?family=Overpass:wght@400;600;700&display=swap" rel="stylesheet" />
+  <meta http-equiv="Content-Security-Policy"
+    content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src *" />
+  <script type="module" src="/src/easteregg.js"></script>
+</head>
+
+<body class="bg-white select-none font-serif">
+  <div id="app" class="p-5 flex flex-col h-dvh"></div>
+  <script type="module" src="/src/main.js"></script>
+</body>
+
 </html>

--- a/frontend/src/renderer/src/App.svelte
+++ b/frontend/src/renderer/src/App.svelte
@@ -2,16 +2,4 @@
   import Router from "./components/Router.svelte";
 </script>
 
-<style>
-  /* Remove focus outline */
-  :global(svg:focus) {
-    outline: none !important;
-  }
-
-  /* Remove focus outline on buttons */
-  :global(button:focus) {
-    outline: none !important;
-  }
-</style>
-
 <Router />

--- a/frontend/src/renderer/src/assets/tailwind.css
+++ b/frontend/src/renderer/src/assets/tailwind.css
@@ -1,3 +1,13 @@
 @import "tailwindcss/base";
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
+
+  /* Remove focus outline */
+  :global(svg:focus) {
+    outline: none !important;
+  }
+
+  /* Remove focus outline on buttons */
+  :global(button:focus) {
+    outline: none !important;
+  }

--- a/frontend/src/renderer/src/components/ErrorBanner.svelte
+++ b/frontend/src/renderer/src/components/ErrorBanner.svelte
@@ -23,14 +23,10 @@
 {#if error}
   <div transition:fade>
     <Banner position="absolute" color="gray">
-      <p class="flex flex-col text-red-800 dark:text-red-200">
+      <p class="flex flex-col text-red-800">
         <span class="flex items-center text-sm font-medium">
-          <span
-            class="inline-flex p-1 me-3 bg-red-100 rounded-full dark:bg-red-900"
-          >
-            <CloseCircleOutline
-              class="w-3 h-3 text-red-500 dark:text-red-300"
-            />
+          <span class="inline-flex p-1 me-3 bg-red-100 rounded-full">
+            <CloseCircleOutline class="w-3 h-3 text-red-500" />
             <span class="sr-only">Error</span>
           </span>
           <span>{error.message}</span>
@@ -49,10 +45,7 @@
           {/if}
         </span>
         {#if error.details && showDetails}
-          <span
-            class="ml-8 text-xs mt-1 text-red-600 dark:text-red-300"
-            transition:fade
-          >
+          <span class="ml-8 text-xs mt-1 text-red-600" transition:fade>
             {error.details}
           </span>
         {/if}

--- a/frontend/src/renderer/src/components/ErrorCard.svelte
+++ b/frontend/src/renderer/src/components/ErrorCard.svelte
@@ -13,14 +13,12 @@
 {#if error}
   <div
     transition:fade
-    class="p-4 bg-red-50 border border-red-200 rounded-lg shadow-sm dark:bg-red-900/10 dark:border-red-800"
+    class="p-4 bg-red-50 border border-red-200 rounded-lg shadow-sm"
   >
-    <p class="flex flex-col text-red-800 dark:text-red-200">
+    <p class="flex flex-col text-red-800">
       <span class="flex items-center text-sm font-medium">
-        <span
-          class="inline-flex p-1 me-3 bg-red-100 rounded-full dark:bg-red-900"
-        >
-          <CloseCircleOutline class="w-3 h-3 text-red-500 dark:text-red-300" />
+        <span class="inline-flex p-1 me-3 bg-red-100 rounded-full">
+          <CloseCircleOutline class="w-3 h-3 text-red-500 " />
           <span class="sr-only">Error</span>
         </span>
         <span>{error.message}</span>
@@ -39,10 +37,7 @@
         {/if}
       </span>
       {#if error.details && showDetails}
-        <span
-          class="ml-8 text-xs mt-1 text-red-600 dark:text-red-300"
-          transition:fade
-        >
+        <span class="ml-8 text-xs mt-1 text-red-600" transition:fade>
           {error.details}
         </span>
       {/if}

--- a/frontend/src/renderer/src/components/Schedule/Schedule.svelte
+++ b/frontend/src/renderer/src/components/Schedule/Schedule.svelte
@@ -5,13 +5,13 @@
   import { navigate } from "../../stores/router.store";
   import { Tabs, TabItem } from "flowbite-svelte";
   import type { UserModel } from "../../models/user.model";
-  
+
   export let user: UserModel;
 </script>
 
-<ScheduleDayView {user}/>
+<ScheduleDayView {user} />
 
-<!--<Tabs tabStyle="full" defaultClass="flex rounded-lg divide-x rtl:divide-x-reverse divide-gray-200 dark:divide-gray-700">
+<!--<Tabs tabStyle="full" defaultClass="flex rounded-lg divide-x rtl:divide-x-reverse divide-gray-200">
   <TabItem open class="w-full">
     <span slot="title">Dag</span>
     <ScheduleDayView />

--- a/frontend/src/renderer/src/routes/Home.svelte
+++ b/frontend/src/renderer/src/routes/Home.svelte
@@ -67,47 +67,41 @@
 
 <!-- Time and Date -->
 <div class="text-center mt-4">
-  <h1 class="text-4xl font-extrabold w-full text-gray-800 dark:text-gray-200">
+  <h1 class="text-4xl font-extrabold w-full text-gray-800">
     {$time}
   </h1>
-  <h2 class="text-xl font-bold w-full text-gray-600 dark:text-gray-300">
+  <h2 class="text-xl font-bold w-full text-gray-600">
     {$date}
   </h2>
 </div>
 
-<main class="flex-grow flex flex-col justify-center items-center overflow-y-auto">
+<main
+  class="flex-grow flex flex-col justify-center items-center overflow-y-auto"
+>
   <div
     class="my-5 w-full max-w-md p-10 mx-auto bg-white rounded-lg border border-gray-200"
   >
     <div class="flex justify-center mb-4">
       <ProfileCardSolid size="lg" class="w-16 h-16 text-primary-600" />
     </div>
-    <h2
-      class="text-3xl font-semibold text-center text-gray-800 dark:text-white"
-    >
+    <h2 class="text-3xl font-semibold text-center text-gray-800">
       Scan je schoolpas
     </h2>
-    <p class="text-center text-sm text-gray-500 dark:text-gray-400 mt-1">
+    <p class="text-center text-sm text-gray-500 mt-1">
       Houd je schoolpas tegen de kaartlezer
     </p>
   </div>
   <div
     class="my-5 w-full max-w-md p-10 mx-auto bg-white rounded-lg border border-gray-200"
   >
-    <h2
-      class="text-3xl font-semibold text-center text-gray-800 dark:text-white"
-    >
-      Inloggen
-    </h2>
-    <p class="text-center text-sm text-gray-500 dark:text-gray-400 mt-1">
+    <h2 class="text-3xl font-semibold text-center text-gray-800">Inloggen</h2>
+    <p class="text-center text-sm text-gray-500 mt-1">
       Voer je leerlingnummer in om verder te gaan
     </p>
 
     <form class="mt-6" on:submit={handleSubmit}>
       <div>
-        <Label
-          for="leerlingnummer"
-          class="block text-sm text-gray-800 dark:text-gray-200"
+        <Label for="leerlingnummer" class="block text-sm text-gray-800"
           >Leerlingnummer</Label
         >
         <Input
@@ -115,7 +109,7 @@
           id="leerlingnummer"
           bind:value={leerlingnummer}
           placeholder="bijv. 2022036"
-          class="w-full px-4 py-2 mt-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 focus:border-primary-400 focus:outline-none focus:ring dark:text-gray-300"
+          class="w-full px-4 py-2 mt-2 border rounded-lg focus:border-primary-400 focus:outline-none focus:ring"
         >
           <UserSolid slot="left" class="w-4 h-4" />
         </Input>
@@ -146,13 +140,13 @@
 </main>
 
 <Modal title="Buiten gebruik" bind:open={offline} dismissable={false}>
-  <p class="text-base leading-relaxed text-gray-500 dark:text-gray-400">
+  <p class="text-base leading-relaxed text-gray-500">
     We konden geen contact opnemen met de server. Controleer uw
     netwerkverbinding.
   </p>
-  <div class="border-t border-gray-200 dark:border-gray-600 my-4"></div>
+  <div class="border-t border-gray-200 my-4"></div>
   <div
-    class="mt-2 text-xs leading-relaxed text-gray-500 dark:text-gray-400 flex space-between justify-around gap-4"
+    class="mt-2 text-xs leading-relaxed text-gray-500 flex space-between justify-around gap-4"
   >
     <div class="grid grid-cols-1 gap-2">
       <p class="flex items-center justify-center gap-2">

--- a/frontend/src/renderer/src/routes/Schedule.svelte
+++ b/frontend/src/renderer/src/routes/Schedule.svelte
@@ -8,17 +8,20 @@
   import { route } from "../stores/router.store";
 
   let user: UserModel = $route.params.user;
-
 </script>
 
 <MenuBar />
 
-<h1 class="text-4xl font-bold text-center my-8">Welkom, {user.firstName.trim()} {user.prefix.trim()} {user.lastName.trim()}!</h1>
+<h1 class="text-4xl font-bold text-center my-8">
+  Welkom, {user.firstName.trim()}
+  {user.prefix.trim()}
+  {user.lastName.trim()}!
+</h1>
 
-<Schedule {user}/>
+<Schedule {user} />
 
 <Footer
-  class="absolute bottom-0 start-0 z-20 w-full p-4 bg-white border-t border-gray-200 shadow md:flex md:items-center md:justify-between md:p-6 dark:bg-gray-800 dark:border-gray-600"
+  class="absolute bottom-0 start-0 z-20 w-full p-4 bg-white border-t border-gray-200 shadow md:flex md:items-center md:justify-between md:p-6"
 >
   <Button class="gap-2 px-2" on:click={() => navigate("/")}
     ><ArrowLeftToBracketOutline />Uitloggen</Button

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -4,6 +4,7 @@ export default {
     "./src/**/*.{html,js,svelte,ts}",
     "./node_modules/flowbite-svelte/**/*.{html,js,svelte,ts}",
   ],
+  darkMode: "class",
   theme: {
     fontFamily: {
       sans: ["Overpass", "sans-serif"],


### PR DESCRIPTION
Onderzoek gedaan naar CORS bug voor de leerlingsites.nl server in development mode. In development mode draait de applicatie op localhost:5173 waarbij CORS regels actief zijn. In production draait de applicatie op een file:// locatie binnen electron. Hierbij zijn geen CORS regels actief. Simpel gezegd ligt in dit geval het probleem bij leerlingsites aangezien deze dus alle OPTIONS requests blocked met een Method not allowed 405. Vandaar dat CORS een error geeft en het dus in development niet werkt maar in production electron wel.

> Mocht je nu graag in development met leerlingsites.nl willen testen dan moet je in main/index.js even webSecurity op false zetten!

Ook nog wat andere kleine fixes gedaan zoals halve dark mode eruit gehaald. We kunnen wel darkmode implementeren maar dat moeten we dan goed doen want nu zat het er gewoon bij sommige elementen door copilot bij gegenereerd en werd het er niet mooier of beter van.

Ook handmatige update button toegevoegd en een over deze applicatie in het menu.

### Application Menu and Auto-Update:
* Added a new application menu with options for update checks, zoom controls, and developer tools in `frontend/src/main/index.js`.
* Updated the auto-update prompt to provide clearer messaging and added an icon to the dialog in `frontend/src/main/index.js`.

### UI Improvements:
* Changed the language attribute to Dutch and added a light mode class in `frontend/src/renderer/index.html`.
* Moved focus outline removal styles to `tailwind.css` from `App.svelte` for better maintainability in `frontend/src/renderer/src/assets/tailwind.css` and `frontend/src/renderer/src/App.svelte`. [[1]](diffhunk://#diff-0376a82bbcfc4362f4789e2a53432f075933e36c905f0c23f3fb435f54834892R4-R13) [[2]](diffhunk://#diff-3f53b488a8711df6baf77a5c85b4b62b9318f3ed578531eec01752c5a701602eL5-L16)
* Removed dark mode specific styles from various components to simplify the UI in `frontend/src/renderer/src/components/ErrorBanner.svelte`, `ErrorCard.svelte`, `Schedule.svelte`, and `Home.svelte`. [[1]](diffhunk://#diff-6e115ef583ba992f1e6b80e16e432a49ddccb07aa45dfe80ef27f90a5f803aceL26-R29) [[2]](diffhunk://#diff-6e115ef583ba992f1e6b80e16e432a49ddccb07aa45dfe80ef27f90a5f803aceL52-R48) [[3]](diffhunk://#diff-f51205b6f35b990bc0f915fbdd7ec22e34286225b66ac777dd44031527343565L16-R21) [[4]](diffhunk://#diff-f51205b6f35b990bc0f915fbdd7ec22e34286225b66ac777dd44031527343565L42-R40) [[5]](diffhunk://#diff-29f2d336772fc4e3719cda6a899ff42380ea0f51868bf1cd702fb52b52ae0db1L14-R14) [[6]](diffhunk://#diff-3082e060d55f5d67d558c02c9d29e5fcd8090ea499b692c2a35bf6ea446513dcL70-R112) [[7]](diffhunk://#diff-3082e060d55f5d67d558c02c9d29e5fcd8090ea499b692c2a35bf6ea446513dcL149-R149) [[8]](diffhunk://#diff-7e45dc5c764a767e273b60b6a26c8e44604d0ed7fa7bd13803daea903d9b07cdL11-R24)

### Configuration:
* Enabled class-based dark mode in the Tailwind configuration file `frontend/tailwind.config.js`.